### PR TITLE
trying out using the RimPy db in sorting too

### DIFF
--- a/util/mods.py
+++ b/util/mods.py
@@ -168,7 +168,7 @@ def get_community_rules(workshop_mods: Dict[str, Any]) -> Dict[str, Any]:
             with open(community_rules_path) as f:
                 rule_data = json.load(f)
                 return rule_data["rules"]
-    show_fatal_error(
+    show_warning(
         "The RimPy mod was not detected.\nPlease install the mod and restart RimSort."
     )
 
@@ -184,7 +184,7 @@ def get_rimpy_db(workshop_mods: Dict[str, Any]) -> Dict[str, Any]:
             with open(db_path) as f:
                 db_data = json.load(f)
                 return db_data["database"]
-    show_fatal_error(
+    show_warning(
         "The RimPy mod was not detected.\nPlease install the mod and restart RimSort."
     )
 

--- a/util/mods.py
+++ b/util/mods.py
@@ -60,15 +60,16 @@ def parse_mod_data(mods_path: str) -> Dict[str, Any]:
                         break
                 # Look for a case-insensitive "About.xml" file
                 invalid_file_path_found = True
-                about_file_name = "About.xml"
-                for temp_file in os.scandir(os.path.join(file.path, about_folder_name)):
-                    if (
-                        temp_file.name.lower() == about_file_name.lower()
-                        and temp_file.is_file()
-                    ):
-                        about_file_name = temp_file.name
-                        invalid_file_path_found = False
-                        break
+                if not invalid_folder_path_found:
+                    about_file_name = "About.xml"
+                    for temp_file in os.scandir(os.path.join(file.path, about_folder_name)):
+                        if (
+                            temp_file.name.lower() == about_file_name.lower()
+                            and temp_file.is_file()
+                        ):
+                            about_file_name = temp_file.name
+                            invalid_file_path_found = False
+                            break
                 # If there was an issue getting the expected path, track and exit
                 if invalid_folder_path_found or invalid_file_path_found:
                     invalid_folders.add(file.name)

--- a/util/mods.py
+++ b/util/mods.py
@@ -319,9 +319,7 @@ def get_dependencies_for_mods(
                 for dependency_folder_id in mod_data["dependencies"]:
                     if dependency_folder_id in folder_to_package_id:
                         # This means the dependency is in all mods
-                        dependency_package_id = folder_to_package_id[
-                            dependency_folder_id
-                        ]
+                        dependency_package_id = folder_to_package_id[dependency_folder_id]
                         add_dependency_to_mod(
                             all_mods.get(mod_data["packageId"].lower()),
                             "dependencies",

--- a/util/xml.py
+++ b/util/xml.py
@@ -12,11 +12,11 @@ def xml_path_to_json(path: str) -> Dict[str, Any]:
     :param path: path to the xml file
     :return: json dict of xml file contents
     """
-    print("Parsing: " + path)
+    # print("Parsing: " + path)
     data = {}
     if os.path.exists(path):
         with open(path, encoding="utf-8") as f:
-            print("Opening " + path)
+            # print("Opening " + path)
             data = xmltodict.parse(f.read())
         return data
 

--- a/view/main_content_panel.py
+++ b/view/main_content_panel.py
@@ -121,10 +121,11 @@ class MainContent:
 
         # Get and cache load order data for ALL mods
         self.community_rules = get_community_rules(mods)
+        self.db_data = get_rimpy_db(mods)
 
         # Calculate and cache dependencies for ALL mods
         self.all_mods_with_dependencies = get_dependencies_for_mods(
-            mods, self.known_expansions, self.community_rules
+            mods, self.known_expansions, self.community_rules, self.db_data
         )
 
     def repopulate_lists(self) -> None:

--- a/view/main_content_panel.py
+++ b/view/main_content_panel.py
@@ -259,6 +259,8 @@ class MainContent:
         for tier_one_mod in tier_one_mods:
             # Tier one mods will only ever reference other tier one mods in their dependencies graph
             tier_one_dependency_graph[tier_one_mod] = dependencies_graph[tier_one_mod]
+    
+        print(tier_one_dependency_graph)
 
         tier_one_sorted = toposort(tier_one_dependency_graph)
         # Reorder active mods alphabetically by their topological level

--- a/view/main_content_panel.py
+++ b/view/main_content_panel.py
@@ -114,10 +114,7 @@ class MainContent:
             populate_expansions_static_data(self.known_expansions, package_id)
 
         # One working Dictionary for ALL mods
-        mods = merge_mod_data(
-            self.local_mods,
-            self.workshop_mods
-        )
+        mods = merge_mod_data(self.local_mods, self.workshop_mods)
 
         # Get and cache load order data for ALL mods
         self.community_rules = get_community_rules(mods)
@@ -207,6 +204,188 @@ class MainContent:
         self._insert_data_into_lists(active_mod_data, inactive_mod_data)
 
     def _do_sort(self) -> None:
+        # Get the live list of active and inactive mods. This is because the user
+        # will likely sort before saving. This is not meant to be used until later
+        # but is useful for getting the ids of the active mods.
+        active_mods_json = (
+            self.active_mods_panel.active_mods_list.get_list_items_by_dict()
+        )
+        active_mod_ids = list(active_mods_json.keys())
+        inactive_mods_json = (
+            self.inactive_mods_panel.inactive_mods_list.get_list_items_by_dict()
+        )
+
+        # Get all active mods and their dependencies (if also active mod)
+        dependencies_graph = {}  # Schema: {item: {dependency1, dependency2, ...}}
+        for package_id, mod_data in active_mods_json.items():
+            dependencies_graph[package_id] = set()
+            if mod_data.get("dependencies"):  # Will either be None, or a set
+                for dependency in mod_data["dependencies"]:
+                    # Only add a dependency if dependency exists in active_mods
+                    # (related to comment about stripping dependencies)
+                    if dependency in active_mod_ids:
+                        dependencies_graph[package_id].add(dependency)
+
+        reverse_dependencies_graph = (
+            {}
+        )  # Schema: {item: {isDependentOn1, isDependentOn2, ...}}
+        for package_id, mod_data in active_mods_json.items():
+            reverse_dependencies_graph[package_id] = set()
+            if mod_data.get("isDependencyOf"):  # Will either be None, or a set
+                for dependent in mod_data["isDependencyOf"]:
+                    if dependent in active_mod_ids:
+                        reverse_dependencies_graph[package_id].add(dependent)
+
+        # Below is a list of mods determined to be "tier one", in the sense that they
+        # should be loaded first before any other regular mod. Tier one mods will have specific
+        # load order needs within themselves, e.g. Harmony before core. There is no guarantee that
+        # this list of mods is exhaustive, so we need to add any other mod that these mods depend on
+        # into this list as well.
+        known_tier_one_mods = {
+            "brrainz.harmony",
+            "ludeon.rimworld",
+            "ludeon.rimworld.royalty",
+            "ludeon.rimworld.ideology",
+            "ludeon.rimworld.biotech",
+            "unlimitedhugs.hugslib",
+        }
+        tier_one_mods = known_tier_one_mods.copy()
+        for known_tier_one_mod in known_tier_one_mods:
+            dependencies_set = self.get_dependencies_recursive(
+                known_tier_one_mod, dependencies_graph
+            )
+            tier_one_mods.update(dependencies_set)
+        tier_one_dependency_graph = {}
+        for tier_one_mod in tier_one_mods:
+            # Tier one mods will only ever reference other tier one mods in their dependencies graph
+            tier_one_dependency_graph[tier_one_mod] = dependencies_graph[tier_one_mod]
+
+        tier_one_sorted = toposort(tier_one_dependency_graph)
+        # Reorder active mods alphabetically by their topological level
+        reordered_tier_one_sorted_with_data = {}
+        for level in tier_one_sorted:
+            temp_mod_dict = {}
+            for package_id in level:
+                temp_mod_dict[package_id] = active_mods_json[package_id]
+            # Sort packages in this topological level by name
+            sorted_temp_mod_dict = sorted(
+                temp_mod_dict.items(), key=lambda x: x[1]["name"], reverse=False
+            )
+            # sorted_mod is tuple of (packageId, json_data)
+            # Add into reordered_active_mods_data (dicts are ordered now)
+            for sorted_mod in sorted_temp_mod_dict:
+                reordered_tier_one_sorted_with_data[sorted_mod[0]] = active_mods_json[
+                    sorted_mod[0]
+                ]
+
+        known_tier_three_mods = {"krkr.rocketman"}
+        tier_three_mods = known_tier_three_mods.copy()
+        for known_tier_three_mod in known_tier_three_mods:
+            rev_dependencies_set = self.get_reverse_dependencies_recursive(
+                known_tier_three_mod, reverse_dependencies_graph
+            )
+            tier_three_mods.update(rev_dependencies_set)
+        tier_three_dependency_graph = {}
+        for tier_three_mod in tier_three_mods:
+            # Tier three mods may reference non-tier-three mods in their dependencies graph,
+            # so it is necessary to trim here
+            tier_three_dependency_graph[tier_three_mod] = set()
+            for possible_add in dependencies_graph[tier_three_mod]:
+                if possible_add in tier_three_mods:
+                    tier_three_dependency_graph[tier_three_mod].add(possible_add)
+
+        tier_three_sorted = toposort(tier_three_dependency_graph)
+        reordered_tier_three_sorted_with_data = {}
+        for level in tier_three_sorted:
+            temp_mod_dict = {}
+            for package_id in level:
+                temp_mod_dict[package_id] = active_mods_json[package_id]
+            # Sort packages in this topological level by name
+            sorted_temp_mod_dict = sorted(
+                temp_mod_dict.items(), key=lambda x: x[1]["name"], reverse=False
+            )
+            # sorted_mod is tuple of (packageId, json_data)
+            # Add into reordered_active_mods_data (dicts are ordered now)
+            for sorted_mod in sorted_temp_mod_dict:
+                reordered_tier_three_sorted_with_data[sorted_mod[0]] = active_mods_json[
+                    sorted_mod[0]
+                ]
+
+        # Now, sort the rest of the mods while removing references to mods in tier one and tier three
+        tier_two_dependency_graph = {}
+        for package_id, mod_data in active_mods_json.items():
+            if package_id not in tier_one_mods and package_id not in tier_three_mods:
+                dependencies = mod_data.get("dependencies")
+                stripped_dependencies = set()
+                if dependencies:
+                    for dependency_id in dependencies:
+                        if (
+                            dependency_id not in tier_one_mods
+                            and dependency_id not in tier_three_mods
+                            and dependency_id in active_mod_ids # Can reference non-active mod
+                        ):
+                            stripped_dependencies.add(dependency_id)
+                tier_two_dependency_graph[package_id] = stripped_dependencies
+
+        tier_two_sorted = toposort(tier_two_dependency_graph)
+        reordered_tier_two_sorted_with_data = {}
+        for level in tier_two_sorted:
+            temp_mod_dict = {}
+            for package_id in level:
+                temp_mod_dict[package_id] = active_mods_json[package_id]
+            # Sort packages in this topological level by name
+            sorted_temp_mod_dict = sorted(
+                temp_mod_dict.items(), key=lambda x: x[1]["name"], reverse=False
+            )
+            # sorted_mod is tuple of (packageId, json_data)
+            # Add into reordered_active_mods_data (dicts are ordered now)
+            for sorted_mod in sorted_temp_mod_dict:
+                reordered_tier_two_sorted_with_data[sorted_mod[0]] = active_mods_json[
+                    sorted_mod[0]
+                ]
+
+        # Add Tier 1, 2, 3 in order
+        combined_tiers = {}
+        for package_id, mod_data in reordered_tier_one_sorted_with_data.items():
+            combined_tiers[package_id] = mod_data
+        for package_id, mod_data in reordered_tier_two_sorted_with_data.items():
+            if package_id in combined_tiers:
+                print("NO")
+            combined_tiers[package_id] = mod_data
+        for package_id, mod_data in reordered_tier_three_sorted_with_data.items():
+            if package_id in combined_tiers:
+                print("NO")
+            combined_tiers[package_id] = mod_data
+
+        self._insert_data_into_lists(combined_tiers, inactive_mods_json)
+
+    def get_reverse_dependencies_recursive(
+        self, package_id, active_mods_rev_dependencies
+    ):
+        reverse_dependencies_set = set()
+        if package_id in active_mods_rev_dependencies:
+            for dependent_id in active_mods_rev_dependencies[package_id]:
+                reverse_dependencies_set.add(dependent_id)
+                reverse_dependencies_set.update(
+                    self.get_reverse_dependencies_recursive(
+                        dependent_id, active_mods_rev_dependencies
+                    )
+                )
+        return reverse_dependencies_set
+
+    def get_dependencies_recursive(self, package_id, active_mods_dependencies):
+        dependencies_set = set()
+        if package_id in active_mods_dependencies:
+            for dependency_id in active_mods_dependencies[package_id]:
+                dependencies_set.add(dependency_id)
+                dependencies_set.update(
+                    self.get_dependencies_recursive(
+                        dependency_id, active_mods_dependencies
+                    )
+                )
+        return dependencies_set
+
+    def _do_sort_dep(self) -> None:
         """
         Sort the active mods list by dependencies and prioritizing alphabetical
         order within topological levels.


### PR DESCRIPTION
Initial onboarding for parsing RimPy's `db.json` and adding the rules in there into the dependency generation. In my testing of 407 mods, this resulted in a 30 count increase in dependency rules, showing that there indeed are rules in `db.json` that are not encapsulated in `communityRules.json` or in the workshop mods `About.xml`s. However, simply adding the dependencies in this manner to the toposort does not get us to parity, so there is still something missing. However, we may be one step closer because of this.