### PR TITLE
Fixing path to icons on bundled app MacOS

### DIFF
--- a/model/mod_list.py
+++ b/model/mod_list.py
@@ -1,4 +1,6 @@
 import logging
+import os
+from pathlib import Path
 from typing import Any, Dict, List
 
 from PySide2.QtCore import *
@@ -45,6 +47,18 @@ class ModListWidget(QListWidget):
         self.horizontalScrollBar().setEnabled(False)
         self.horizontalScrollBar().setVisible(False)
 
+        # Store icon paths
+        self.steam_icon_path = str(
+            Path(
+                os.path.join(os.path.dirname(__file__), "../data/steam_icon.png")
+            ).resolve()
+        )
+        self.ludeon_icon_path = str(
+            Path(
+                os.path.join(os.path.dirname(__file__), "../data/ludeon_icon.png")
+            ).resolve()
+        )
+
         # Allow inserting custom list items
         self.model().rowsInserted.connect(
             self.handle_rows_inserted, Qt.QueuedConnection
@@ -86,7 +100,9 @@ class ModListWidget(QListWidget):
             item = self.item(idx)
             if item is not None and self.itemWidget(item) is None:
                 data = item.data(Qt.UserRole)
-                widget = ModListItemInner(data, self.width())
+                widget = ModListItemInner(
+                    data, self.width(), self.steam_icon_path, self.ludeon_icon_path
+                )
                 item.setSizeHint(widget.sizeHint())
                 self.setItemWidget(item, widget)
         self.list_update_signal.emit(str(self.count()))

--- a/model/mod_list_item.py
+++ b/model/mod_list_item.py
@@ -14,7 +14,13 @@ class ModListItemInner(QWidget):
     mod and display relevant data on a mod list.
     """
 
-    def __init__(self, data: Dict[str, Any], container_width: float) -> None:
+    def __init__(
+        self,
+        data: Dict[str, Any],
+        container_width: float,
+        steam_icon_path: str,
+        ludeon_icon_path: str,
+    ) -> None:
         """
         Initialize the QWidget with mod data.
         All tags are set to the corresponding field if it
@@ -31,6 +37,8 @@ class ModListItemInner(QWidget):
         # in this variable. This is exactly equal to the dict value of a
         # single all_mods key-value
         self.json_data = data
+        self.steam_icon_path = steam_icon_path
+        self.ludeon_icon_path = ludeon_icon_path
 
         # Visuals
         self.setToolTip(self.get_tool_tip_text())
@@ -90,9 +98,9 @@ class ModListItemInner(QWidget):
         :return icon: QIcon object set to the path of the cooresponding icon image
         """
         if self.json_data.get("isExpansion"):
-            return QIcon("data/ludeon_icon.png")
+            return QIcon(self.ludeon_icon_path)
         elif self.json_data.get("isWorkshop"):
-            return QIcon("data/steam_icon.png")
+            return QIcon(self.steam_icon_path)
         elif self.json_data.get("isLocal"):
             return self.style().standardIcon(QStyle.SP_FileDialogStart)
         else:


### PR DESCRIPTION
For an unknown reason the bundled app on MacOS isn't able to display the icons in the data folder, even though it is included in the MacOS package contents. It worked fine on Windows. This PR uses the same method of referencing the `style.qss` with the icons. Tested to work on both Windows and Mac bundled apps.