### PR TITLE
Alpha 1.0.1 patches

### DIFF
--- a/sub_view/active_mods_panel.py
+++ b/sub_view/active_mods_panel.py
@@ -292,7 +292,11 @@ class ActiveModList(QWidget):
     def signal_active_mods_search(self, pattern: str) -> None:
         wni = self.active_mods_list.get_widgets_and_items()
         for widget, item in wni:
-            if pattern and not pattern.lower() in widget.json_data["name"].lower():
+            if (
+                pattern
+                and not pattern.lower() in widget.json_data["name"].lower()
+                and not pattern.lower() in widget.json_data["packageId"].lower()
+            ):
                 item.setHidden(True)
             else:
                 item.setHidden(False)
@@ -307,8 +311,6 @@ class ActiveModList(QWidget):
             else:
                 num_visible += 1
         if self.active_mods_search.text():
-            self.num_mods.setText(
-                f"Active [{num_visible}/{num_hidden + num_visible}]"
-            )
+            self.num_mods.setText(f"Active [{num_visible}/{num_hidden + num_visible}]")
         else:
             self.num_mods.setText(f"Active [{num_hidden + num_visible}]")

--- a/sub_view/active_mods_panel.py
+++ b/sub_view/active_mods_panel.py
@@ -94,6 +94,8 @@ class ActiveModList(QWidget):
         # self.active_mods_search.setCompleter(self.completer)
 
         self.game_version = ""
+        self.all_mods = {}
+        self.steam_package_id_to_name = {}
 
         # Connect signals and slots
         self.active_mods_list.list_update_signal.connect(
@@ -243,7 +245,19 @@ class ActiveModList(QWidget):
             if missing_dependencies:
                 error_tool_tip_text += "\n\nMissing Dependencies:"
                 for dependency_id in missing_dependencies:
-                    error_tool_tip_text += f"\n  * {dependency_id}"
+                    # If dependency is installed, we can get its name
+                    if dependency_id in self.all_mods:
+                        error_tool_tip_text += (
+                            f"\n  * {self.all_mods[dependency_id]['name']}"
+                        )
+                    # Otherwise, we might be able to get it from RimPy Steam DB
+                    elif dependency_id in self.steam_package_id_to_name:
+                        error_tool_tip_text += (
+                            f"\n  * {self.steam_package_id_to_name[dependency_id]}"
+                        )
+                    # Other-otherwise, just use the id
+                    else:
+                        error_tool_tip_text += f"\n  * {dependency_id}"
 
             conflicting_incompatibilities = package_id_to_errors[package_id][
                 "conflicting_incompatibilities"
@@ -271,10 +285,8 @@ class ActiveModList(QWidget):
                 for load_after_id in load_after_violations:
                     load_after_name = active_mods[load_after_id]["name"]
                     warning_tool_tip_text += f"\n  * {load_after_name}"
-            
-            version_mismatch = package_id_to_errors[package_id][
-                "version_mismatch"
-            ]
+
+            version_mismatch = package_id_to_errors[package_id]["version_mismatch"]
             if version_mismatch:
                 warning_tool_tip_text += "\n\nMod and Game Version Mismatch"
 

--- a/sub_view/active_mods_panel.py
+++ b/sub_view/active_mods_panel.py
@@ -93,6 +93,8 @@ class ActiveModList(QWidget):
         # self.completer.setCaseSensitivity(Qt.CaseInsensitive)
         # self.active_mods_search.setCompleter(self.completer)
 
+        self.game_version = ""
+
         # Connect signals and slots
         self.active_mods_list.list_update_signal.connect(
             self.handle_internal_mod_list_updated
@@ -136,7 +138,46 @@ class ActiveModList(QWidget):
                 "conflicting_incompatibilities": set(),
                 "load_before_violations": set(),
                 "load_after_violations": set(),
+                "version_mismatch": True,
             }
+
+            # Check version
+            if self.game_version:
+                if "supportedVersions" in mod_data:
+                    if "li" in mod_data["supportedVersions"]:
+                        supported_versions = mod_data["supportedVersions"]["li"]
+                        # supported_versions is either a string or list of strings
+                        if isinstance(supported_versions, str):
+                            if self.game_version.startswith(supported_versions):
+                                package_id_to_errors[package_id][
+                                    "version_mismatch"
+                                ] = False
+                        elif isinstance(supported_versions, list):
+                            is_supported = False
+                            for supported_version in supported_versions:
+                                if isinstance(supported_version, str):
+                                    if self.game_version.startswith(supported_version):
+                                        is_supported = True
+                                else:
+                                    logger.error(
+                                        f"supportedVersion in list is not str: {supported_versions}"
+                                    )
+                            if is_supported:
+                                package_id_to_errors[package_id][
+                                    "version_mismatch"
+                                ] = False
+                        else:
+                            logger.error(
+                                f"supportedVersions value not str or list: {supported_versions}"
+                            )
+                    else:
+                        logger.error(
+                            f"No li tag found in supportedVersions value: {mod_data['supportedVersions']}"
+                        )
+                else:
+                    logger.error(
+                        f"No supportedVersions key found in mod data: {mod_data}"
+                    )
 
             # Check dependencies
             if mod_data.get("dependencies"):
@@ -194,50 +235,59 @@ class ActiveModList(QWidget):
                                 ].add(load_this_after[0])
 
             # Consolidate results
-            tool_tip_text = ""
+            error_tool_tip_text = ""
+            warning_tool_tip_text = ""
             missing_dependencies = package_id_to_errors[package_id][
                 "missing_dependencies"
             ]
             if missing_dependencies:
-                tool_tip_text += "\nMissing Dependencies:"
+                error_tool_tip_text += "\n\nMissing Dependencies:"
                 for dependency_id in missing_dependencies:
-                    tool_tip_text += f"\n  * {dependency_id}"
+                    error_tool_tip_text += f"\n  * {dependency_id}"
 
             conflicting_incompatibilities = package_id_to_errors[package_id][
                 "conflicting_incompatibilities"
             ]
             if conflicting_incompatibilities:
-                tool_tip_text += "\nIncompatibilities:"
+                error_tool_tip_text += "\n\nIncompatibilities:"
                 for incompatibility_id in conflicting_incompatibilities:
                     incompatibility_name = active_mods[incompatibility_id]["name"]
-                    tool_tip_text += f"\n  * {incompatibility_name}"
+                    error_tool_tip_text += f"\n  * {incompatibility_name}"
 
             load_before_violations = package_id_to_errors[package_id][
                 "load_before_violations"
             ]
             if load_before_violations:
-                tool_tip_text += "\nShould be Loaded After:"
+                warning_tool_tip_text += "\n\nShould be Loaded After:"
                 for load_before_id in load_before_violations:
                     load_before_name = active_mods[load_before_id]["name"]
-                    tool_tip_text += f"\n  * {load_before_name}"
+                    warning_tool_tip_text += f"\n  * {load_before_name}"
 
             load_after_violations = package_id_to_errors[package_id][
                 "load_after_violations"
             ]
             if load_after_violations:
-                tool_tip_text += "\nShould be Loaded Before:"
+                warning_tool_tip_text += "\n\nShould be Loaded Before:"
                 for load_after_id in load_after_violations:
                     load_after_name = active_mods[load_after_id]["name"]
-                    tool_tip_text += f"\n  * {load_after_name}"
+                    warning_tool_tip_text += f"\n  * {load_after_name}"
+            
+            version_mismatch = package_id_to_errors[package_id][
+                "version_mismatch"
+            ]
+            if version_mismatch:
+                warning_tool_tip_text += "\n\nMod and Game Version Mismatch"
 
             # Set icon if necessary
             current_package_index = package_id_to_index[package_id]
             item_widget_at_index = self.active_mods_list.get_item_widget_at_index(
                 current_package_index
             )
+            # Set icon tooltip
             if item_widget_at_index:
-                if tool_tip_text:
+                if warning_tool_tip_text or error_tool_tip_text:
                     item_widget_at_index.warning_icon_label.setHidden(False)
+                    tool_tip_text = error_tool_tip_text + warning_tool_tip_text
                     item_widget_at_index.warning_icon_label.setToolTip(
                         tool_tip_text.lstrip()
                     )
@@ -250,12 +300,12 @@ class ActiveModList(QWidget):
                 num_errors += 1
                 total_error_text += f"\n\n{active_mods[package_id]['name']}"
                 total_error_text += "\n============================="
-                total_error_text += tool_tip_text
-            elif load_before_violations or load_after_violations:
+                total_error_text += error_tool_tip_text.replace("\n\n", "\n")
+            if load_before_violations or load_after_violations or version_mismatch:
                 num_warnings += 1
                 total_warning_text += f"\n\n{active_mods[package_id]['name']}"
                 total_warning_text += "\n============================="
-                total_warning_text += tool_tip_text
+                total_warning_text += warning_tool_tip_text.replace("\n\n", "\n")
 
         if total_error_text or total_warning_text or num_errors or num_warnings:
             self.errors_summary_frame.setHidden(False)

--- a/sub_view/inactive_mods_panel.py
+++ b/sub_view/inactive_mods_panel.py
@@ -74,7 +74,11 @@ class InactiveModList:
     def signal_inactive_mods_search(self, pattern: str) -> None:
         wni = self.inactive_mods_list.get_widgets_and_items()
         for widget, item in wni:
-            if pattern and not pattern.lower() in widget.json_data["name"].lower():
+            if (
+                pattern
+                and not pattern.lower() in widget.json_data["name"].lower()
+                and not pattern.lower() in widget.json_data["packageId"].lower()
+            ):
                 item.setHidden(True)
             else:
                 item.setHidden(False)

--- a/util/mods.py
+++ b/util/mods.py
@@ -186,7 +186,7 @@ def parse_mod_data(mods_path: str, intent: str) -> Dict[str, Any]:
     return mods
 
 
-def get_installed_expansions(game_path: str) -> Dict[str, Any]:
+def get_installed_expansions(game_path: str, game_version: str) -> Dict[str, Any]:
     """
     Given a path to the game's install folder, return a dict
     containing data for all of the installed expansions
@@ -216,15 +216,20 @@ def get_installed_expansions(game_path: str) -> Dict[str, Any]:
     # Base game and expansion About.xml do not contain name, so these
     # must be manually added
     logger.info("Manually populating names for BASE/EXPANSION data")
-    for package_id in mod_data.keys():
+    for package_id, data in mod_data.items():
         if package_id == "ludeon.rimworld":
-            mod_data[package_id]["name"] = "Core (Base game)"
-        if package_id == "ludeon.rimworld.royalty":
-            mod_data[package_id]["name"] = "Royalty (DLC #1)"
-        if package_id == "ludeon.rimworld.ideology":
-            mod_data[package_id]["name"] = "Ideology (DLC #2)"
-        if package_id == "ludeon.rimworld.biotech":
-            mod_data[package_id]["name"] = "Biotech (DLC #3)"
+            data["name"] = "Core (Base game)"
+        elif package_id == "ludeon.rimworld.royalty":
+            data["name"] = "Royalty (DLC #1)"
+        elif package_id == "ludeon.rimworld.ideology":
+            data["name"] = "Ideology (DLC #2)"
+        elif package_id == "ludeon.rimworld.biotech":
+            data["name"] = "Biotech (DLC #3)"
+        else:
+            logger.error(
+                f"An unknown mod has been found in the expansions folder: {package_id} {data}"
+            )
+        data["supportedVersions"] = {"li": game_version}
     logger.info(
         "Finished getting installed expansions, returning final BASE/EXPANSIONS data now"
     )
@@ -885,7 +890,7 @@ def add_load_rule_to_mod(
                     logger.error(
                         f"Load rule is not an expected str or dict: {dependency}"
                     )
-                
+
                 if dependency_id:
                     if dependency_id in all_mods:
                         mod_data[explicit_key].add((dependency_id, True))

--- a/view/game_configuration_panel.py
+++ b/view/game_configuration_panel.py
@@ -190,9 +190,7 @@ class GameConfiguration(QObject):
         self.local_folder_select_button.clicked.connect(self.set_local_folder)
         self.local_folder_select_button.setObjectName("RightButton")
         self.local_folder_select_button.setToolTip(
-            "Set the Local Mods directory.\n"
-            "On Mac, set this to the game install directory to use the\n"
-            "default game install directory's Mods folder."
+            "Set the Local Mods directory."
         )
 
         # WIDGETS INTO CONTAINER LAYOUTS
@@ -685,17 +683,6 @@ class GameConfiguration(QObject):
                 self.update_persistent_storage("game_folder", os_paths[0])
             else:
                 logger.info("Value already set for game folder. Passing")
-            if system_name == "Darwin":
-                logger.info("Additionally, setting local mods folder on MacOS")
-                # On mac the Mods folder is the Rimworld folder
-                if not self.local_folder_line.text():
-                    logger.info(
-                        "No value set currently for local mods folder. Overwriting with autodetected path"
-                    )
-                    self.local_folder_line.setText(os_paths[0])
-                    self.update_persistent_storage("local_folder", os_paths[0])
-                else:
-                    logger.info("Value already set for local mods folder. Passing")
         else:
             logger.warning(
                 f"Autodetected game folder path does not exist: {os_paths[0]}"
@@ -734,24 +721,27 @@ class GameConfiguration(QObject):
             )
 
         # Checking for an existing Rimworld/Mods folder
-        if system_name != "Darwin":
+        rimworld_mods_path = ""
+        if system_name == "Darwin":
+            rimworld_mods_path = os.path.join(os_paths[0], "RimWorldMac.app", "Mods")
+        else:
             rimworld_mods_path = os.path.join(os_paths[0], "Mods")
-            if os.path.exists(rimworld_mods_path):
+        if os.path.exists(rimworld_mods_path):
+            logger.info(
+                f"Autodetected local mods folder path exists: {rimworld_mods_path}"
+            )
+            if not self.local_folder_line.text():
                 logger.info(
-                    f"Autodetected local mods folder path exists: {rimworld_mods_path}"
+                    "No value set currently for local mods folder. Overwriting with autodetected path"
                 )
-                if not self.local_folder_line.text():
-                    logger.info(
-                        "No value set currently for local mods folder. Overwriting with autodetected path"
-                    )
-                    self.local_folder_line.setText(rimworld_mods_path)
-                    self.update_persistent_storage("local_folder", rimworld_mods_path)
-                else:
-                    logger.info("Value already set for local mods folder. Passing")
+                self.local_folder_line.setText(rimworld_mods_path)
+                self.update_persistent_storage("local_folder", rimworld_mods_path)
             else:
-                logger.warning(
-                    f"Autodetected game folder path does not exist: {rimworld_mods_path}"
-                )
+                logger.info("Value already set for local mods folder. Passing")
+        else:
+            logger.warning(
+                f"Autodetected game folder path does not exist: {rimworld_mods_path}"
+            )
 
     def get_game_folder_path(self):
         logger.info(

--- a/view/main_content_panel.py
+++ b/view/main_content_panel.py
@@ -179,12 +179,23 @@ class MainContent:
             )
 
         # Calculate and cache dependencies for ALL mods
-        self.all_mods_with_dependencies = get_dependencies_for_mods(
+        (
+            self.all_mods_with_dependencies,
+            self.info_from_steam_package_id_to_name,
+        ) = get_dependencies_for_mods(
             self.expansions,
             mods,
             self.steam_db_rules,
             self.community_rules,  # TODO add user defined customRules from future customRules.json
         )
+
+        # Feed all_mods and Steam DB info to Active Mods list to surface
+        # names instead of package_ids when able
+        self.active_mods_panel.all_mods = self.all_mods_with_dependencies
+        self.active_mods_panel.steam_package_id_to_name = (
+            self.info_from_steam_package_id_to_name
+        )
+
         logger.info("Finished refreshing cache calculations")
 
     def repopulate_lists(self, is_initial: bool = False) -> None:

--- a/view/main_content_panel.py
+++ b/view/main_content_panel.py
@@ -85,6 +85,8 @@ class MainContent:
         self.active_mods_data_restore_state = []
         self.inactive_mods_data_restore_state = []
 
+        self.game_version = ""
+
         # Check if paths have been set
         if self.game_configuration.check_if_essential_paths_are_set():
             # Run expensive calculations to set cache data
@@ -125,16 +127,18 @@ class MainContent:
         but also after ModsConfig.xml path has been changed).
         """
         logger.info("Refreshing cache calculations")
-        # Get and cache installed base game / DLC data
-        self.expansions = get_installed_expansions(
-            self.game_configuration.get_game_folder_path()
-        )
 
         # Get & set Rimworld version string
         self.game_version = get_game_version(
             self.game_configuration.get_game_folder_path()
         )
         self.game_configuration.game_version_line.setText(self.game_version)
+        self.active_mods_panel.game_version = self.game_version
+
+        # Get and cache installed base game / DLC data
+        self.expansions = get_installed_expansions(
+            self.game_configuration.get_game_folder_path(), self.game_version
+        )
 
         # Get and cache installed local/custom mods
         self.local_mods = get_local_mods(


### PR DESCRIPTION
A number of small improvements and fixes following feedback from the Alpha 1.0.1 release (thanks LM!). The following list of changes were made:

- Autodetect on Mac now goes into the `RimWorldMac.app/Mods` folder. Nothing was changed with how local mods are actually collected. The issue was that the previous local mods path for Mac was set to the game folder, where there are no mods. Getting local mods on Mac should now work.
- Some About.xml files have weird `MayRequire` tags, which we were able to parse fine for dependencies but crashed on load rules. Load rules should now work for this.
- Search bars now filter for package_ids in addition to names
- Version mismatch errors are now surfaced on mod list items and warnings/error summary
- Warnings/errors are now differentiated a bit more; a mod with both warnings and errors will have an entry in both the warnings summary and errors summary
- Mod names are now surfaced in dependency error tooltips where we are able to get the name