### PR TITLE
Refactoring and mypy compliance

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,9 +4,8 @@ import sys
 import traceback
 from pathlib import Path
 
-from PySide2.QtCore import *
-from PySide2.QtGui import *
-from PySide2.QtWidgets import *
+from PySide2.QtCore import QSize
+from PySide2.QtWidgets import QApplication, QMainWindow, QVBoxLayout, QWidget
 
 from util.error import show_fatal_error
 from util.proxy_style import ProxyStyle

--- a/model/animation_label.py
+++ b/model/animation_label.py
@@ -1,6 +1,5 @@
-from PySide2.QtCore import *
-from PySide2.QtGui import *
-from PySide2.QtWidgets import *
+from PySide2.QtCore import QPropertyAnimation, QTimer, QEasingCurve
+from PySide2.QtWidgets import QLabel, QGraphicsOpacityEffect
 
 
 class AnimationLabel(QLabel):

--- a/model/mod_list.py
+++ b/model/mod_list.py
@@ -1,11 +1,11 @@
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict
 
-from PySide2.QtCore import *
-from PySide2.QtGui import *
-from PySide2.QtWidgets import *
+from PySide2.QtCore import QModelIndex, Qt, Signal
+from PySide2.QtGui import QDropEvent, QFocusEvent
+from PySide2.QtWidgets import QAbstractItemView, QListWidget, QListWidgetItem
 
 from model.mod_list_item import ModListItemInner
 

--- a/model/mod_list.py
+++ b/model/mod_list.py
@@ -1,7 +1,7 @@
 import logging
 import os
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Optional
 
 from PySide2.QtCore import QModelIndex, Qt, Signal
 from PySide2.QtGui import QDropEvent, QFocusEvent
@@ -71,7 +71,7 @@ class ModListWidget(QListWidget):
 
         logger.info("Finished ModListWidget initialization")
 
-    def recreate_mod_list(self, mods: Dict[str, Any]) -> None:
+    def recreate_mod_list(self, mods: dict[str, Any]) -> None:
         """
         Clear all mod items and add new ones from a dict.
 
@@ -124,17 +124,18 @@ class ModListWidget(QListWidget):
         self.list_update_signal.emit("drop")
         return ret
 
-    def get_item_widget_at_index(self, idx: int) -> ModListItemInner:
+    def get_item_widget_at_index(self, idx: int) -> Optional[ModListItemInner]:
         item = self.item(idx)
         if item:
             return self.itemWidget(item)
+        return None
 
-    def get_widgets_and_items(self):
+    def get_widgets_and_items(self) -> list[tuple[ModListItemInner, QListWidgetItem]]:
         return [
             (self.itemWidget(self.item(i)), self.item(i)) for i in range(self.count())
         ]
 
-    def get_list_items_by_dict(self) -> Dict[str, Any]:
+    def get_list_items_by_dict(self) -> dict[str, Any]:
         """
         Get a dict of all row item's widgets data. Equal to `mods` in
         recreate mod list.

--- a/model/mod_list_item.py
+++ b/model/mod_list_item.py
@@ -77,12 +77,18 @@ class ModListItemInner(QWidget):
 
     def get_tool_tip_text(self) -> str:
         name_line = f"Mod: {self.json_data.get('name', 'UNKNOWN')}\n"
-        if self.json_data.get("authors"):
-            list_of_authors = self.json_data.get("authors")["li"]
-            authors_text = ", ".join(list_of_authors)
-            author_line = f"Authors: {authors_text}\n"
+
+        author_line = "Author: UNKNOWN\n"
+        if "authors" in self.json_data:
+            if "li" in self.json_data["authors"]:
+                list_of_authors = self.json_data["authors"]["li"]
+                authors_text = ", ".join(list_of_authors)
+                author_line = f"Authors: {authors_text}\n"
+            else:
+                logger.error(f"[authors] tag does not contain [li] tag: {self.json_data['authors']}")
         else:
-            author_line = f"Authors: {self.json_data.get('author', 'UNKNOWN')}\n"
+            author_line = f"Author: {self.json_data.get('author', 'UNKNOWN')}\n"
+
         package_id_line = f"PackageID: {self.json_data.get('packageId', 'UNKNOWN')}\n"
         # TODO: version information should be read from manifest file, which is not currently
         # being used. This file actually also contains some load rule data so use that too.

--- a/model/mod_list_item.py
+++ b/model/mod_list_item.py
@@ -1,9 +1,9 @@
 import logging
 from typing import Any, Dict
 
-from PySide2.QtCore import *
-from PySide2.QtGui import *
-from PySide2.QtWidgets import *
+from PySide2.QtCore import QRectF, QSize, Qt
+from PySide2.QtGui import QFontMetrics, QIcon
+from PySide2.QtWidgets import QHBoxLayout, QLabel, QStyle, QWidget
 
 logger = logging.getLogger(__name__)
 

--- a/model/scroll_label.py
+++ b/model/scroll_label.py
@@ -13,7 +13,7 @@ class ScrollLabel(QScrollArea):
     part of the mod ifo panel.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
         """
         Initialize the class.
         """
@@ -50,9 +50,9 @@ class ScrollLabel(QScrollArea):
 
         logger.info("Finished ScrollLabel initialization")
 
-    def setText(self, text):
+    def setText(self, text: str) -> None:
         self.label.setText(text)
 
-    def text(self):
+    def text(self) -> str:
         get_text = self.label.text()
         return get_text

--- a/model/scroll_label.py
+++ b/model/scroll_label.py
@@ -1,8 +1,7 @@
 import logging
 
-from PySide2.QtCore import *
-from PySide2.QtGui import *
-from PySide2.QtWidgets import *
+from PySide2.QtCore import Qt
+from PySide2.QtWidgets import QFrame, QLabel, QScrollArea, QVBoxLayout
 
 logger = logging.getLogger(__name__)
 

--- a/panel/settings_panel.py
+++ b/panel/settings_panel.py
@@ -1,9 +1,8 @@
 import logging
 from functools import partial
 
-from PySide2.QtCore import *
-from PySide2.QtGui import *
-from PySide2.QtWidgets import *
+from PySide2.QtCore import Qt, Signal
+from PySide2.QtWidgets import QComboBox, QDialog, QLabel, QPushButton, QVBoxLayout
 
 logger = logging.getLogger(__name__)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,16 @@
+[mypy]
+disallow_any_generics = True
+# disallow_any_unimported = True
+disallow_incomplete_defs = True
+# disallow_subclassing_any = True
+disallow_untyped_calls = True
+disallow_untyped_decorators = True
+disallow_untyped_defs = True
+pretty = True
+warn_redundant_casts = True
+warn_return_any = True
+warn_unused_configs = True
+warn_unused_ignores = True
+
+[mypy-PySide2.*]
+ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ disallow_untyped_decorators = True
 disallow_untyped_defs = True
 pretty = True
 warn_redundant_casts = True
-warn_return_any = True
+# warn_return_any = True
 warn_unused_configs = True
 warn_unused_ignores = True
 

--- a/sort/rimpy_sort.py
+++ b/sort/rimpy_sort.py
@@ -1,12 +1,12 @@
 import logging
-from typing import Any, Dict
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
 
 def do_rimpy_sort(
-    dependency_graph: Dict[str, set], active_mods_json: Dict[str, Any]
-) -> Dict[str, Any]:
+    dependency_graph: dict[str, set[str]], active_mods_json: dict[str, Any]
+) -> dict[str, Any]:
     logger.info(f"Starting RimPy sort for {len(dependency_graph)} mods")
     # Get an alphabetized list of dependencies
     active_mods_id_to_name = dict((k, v["name"]) for k, v in active_mods_json.items())
@@ -45,12 +45,12 @@ def do_rimpy_sort(
 
 
 def recursively_force_insert(
-    mods_load_order,
-    dependency_graph,
-    package_id,
-    active_mods_json,
-    index_just_appended,
-):
+    mods_load_order: list[str],
+    dependency_graph: dict[str, set[str]],
+    package_id: str,
+    active_mods_json: dict[str, Any],
+    index_just_appended: int,
+) -> None:
     # Get the reverse alphabetized list (by name) of the current mod's dependencies
     deps_of_package = dependency_graph[package_id]
     deps_id_to_name = {}

--- a/sort/topo_sort.py
+++ b/sort/topo_sort.py
@@ -1,5 +1,5 @@
 import logging
-from typing import Any, Dict
+from typing import Any
 
 from toposort import toposort
 
@@ -7,8 +7,8 @@ logger = logging.getLogger(__name__)
 
 
 def do_topo_sort(
-    dependency_graph: Dict[str, set], active_mods_json: Dict[str, Any]
-) -> Dict[str, Any]:
+    dependency_graph: dict[str, set[str]], active_mods_json: dict[str, Any]
+) -> dict[str, Any]:
     """
     Sort mods using the topological sort algorithm. For each
     topological level, sort the mods alphabetically.

--- a/sub_view/actions_panel.py
+++ b/sub_view/actions_panel.py
@@ -1,7 +1,7 @@
 import logging
 from functools import partial
 
-from PySide2.QtCore import Qt, Signal
+from PySide2.QtCore import QPoint, Qt, Signal
 from PySide2.QtWidgets import QMenu, QPushButton, QVBoxLayout, QWidget
 
 logger = logging.getLogger(__name__)
@@ -88,10 +88,10 @@ class Actions(QWidget):
         logger.info("Finished Actions initialization")
 
     @property
-    def panel(self):
+    def panel(self) -> QVBoxLayout:
         return self._panel
 
-    def contextMenuEvent(self, point):
+    def contextMenuEvent(self, point: QPoint) -> None:
         contextMenu = QMenu(self)
         set_run_args = contextMenu.addAction("Edit Run Args")
         set_run_args.triggered.connect(

--- a/sub_view/actions_panel.py
+++ b/sub_view/actions_panel.py
@@ -1,9 +1,8 @@
 import logging
 from functools import partial
 
-from PySide2.QtCore import *
-from PySide2.QtGui import *
-from PySide2.QtWidgets import *
+from PySide2.QtCore import Qt, Signal
+from PySide2.QtWidgets import QMenu, QPushButton, QVBoxLayout, QWidget
 
 logger = logging.getLogger(__name__)
 

--- a/sub_view/active_mods_panel.py
+++ b/sub_view/active_mods_panel.py
@@ -1,9 +1,16 @@
 import logging
-from typing import Any, Dict
 
-from PySide2.QtCore import *
-from PySide2.QtGui import *
-from PySide2.QtWidgets import *
+from PySide2.QtCore import QSize, Qt
+from PySide2.QtWidgets import (
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QStyle,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
 
 from model.mod_list import ModListWidget
 

--- a/sub_view/active_mods_panel.py
+++ b/sub_view/active_mods_panel.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Any
 
 from PySide2.QtCore import QSize, Qt
 from PySide2.QtWidgets import (
@@ -6,6 +7,7 @@ from PySide2.QtWidgets import (
     QHBoxLayout,
     QLabel,
     QLineEdit,
+    QListWidgetItem,
     QStyle,
     QToolButton,
     QVBoxLayout,
@@ -13,6 +15,7 @@ from PySide2.QtWidgets import (
 )
 
 from model.mod_list import ModListWidget
+from model.mod_list_item import ModListItemInner
 
 logger = logging.getLogger(__name__)
 
@@ -101,8 +104,8 @@ class ActiveModList(QWidget):
         # self.active_mods_search.setCompleter(self.completer)
 
         self.game_version = ""
-        self.all_mods = {}
-        self.steam_package_id_to_name = {}
+        self.all_mods: dict[str, Any] = {}
+        self.steam_package_id_to_name: dict[str, Any] = {}
 
         # Connect signals and slots
         self.active_mods_list.list_update_signal.connect(
@@ -111,7 +114,7 @@ class ActiveModList(QWidget):
 
         logger.info("Finished ActiveModList initialization")
 
-    def recalculate_internal_list_errors(self):
+    def recalculate_internal_list_errors(self) -> None:
         """
         Whenever the active mod list has items added to it,
         or has items removed from it, or has items rearranged around within it,
@@ -303,7 +306,7 @@ class ActiveModList(QWidget):
                 current_package_index
             )
             # Set icon tooltip
-            if item_widget_at_index:
+            if item_widget_at_index is not None:
                 if warning_tool_tip_text or error_tool_tip_text:
                     item_widget_at_index.warning_icon_label.setHidden(False)
                     tool_tip_text = error_tool_tip_text + warning_tool_tip_text
@@ -354,7 +357,7 @@ class ActiveModList(QWidget):
 
         self.recalculate_internal_list_errors()
 
-    def clear_active_mods_search(self):
+    def clear_active_mods_search(self) -> None:
         self.active_mods_search.setText("")
         self.active_mods_search.clearFocus()
 
@@ -371,7 +374,9 @@ class ActiveModList(QWidget):
                 item.setHidden(False)
         self.update_count(wni)
 
-    def update_count(self, widgets_and_items):
+    def update_count(
+        self, widgets_and_items: list[tuple[ModListItemInner, QListWidgetItem]]
+    ) -> None:
         num_hidden = 0
         num_visible = 0
         for w, i in widgets_and_items:

--- a/sub_view/inactive_mods_panel.py
+++ b/sub_view/inactive_mods_panel.py
@@ -1,9 +1,7 @@
 import logging
-from typing import Any, Dict, List
 
-from PySide2.QtCore import *
-from PySide2.QtGui import *
-from PySide2.QtWidgets import *
+from PySide2.QtCore import Qt
+from PySide2.QtWidgets import QLabel, QLineEdit, QToolButton, QVBoxLayout
 
 from model.mod_list import ModListWidget
 

--- a/sub_view/inactive_mods_panel.py
+++ b/sub_view/inactive_mods_panel.py
@@ -1,9 +1,16 @@
 import logging
 
 from PySide2.QtCore import Qt
-from PySide2.QtWidgets import QLabel, QLineEdit, QToolButton, QVBoxLayout
+from PySide2.QtWidgets import (
+    QLabel,
+    QLineEdit,
+    QListWidgetItem,
+    QToolButton,
+    QVBoxLayout,
+)
 
 from model.mod_list import ModListWidget
+from model.mod_list_item import ModListItemInner
 
 logger = logging.getLogger(__name__)
 
@@ -65,7 +72,7 @@ class InactiveModList:
             # self.num_mods.setText(f"Inactive [{count}]")
             self.update_count(self.inactive_mods_list.get_widgets_and_items())
 
-    def clear_inactive_mods_search(self):
+    def clear_inactive_mods_search(self) -> None:
         self.inactive_mods_search.setText("")
         self.inactive_mods_search.clearFocus()
 
@@ -82,7 +89,9 @@ class InactiveModList:
                 item.setHidden(False)
         self.update_count(wni)
 
-    def update_count(self, widgets_and_items):
+    def update_count(
+        self, widgets_and_items: list[tuple[ModListItemInner, QListWidgetItem]]
+    ) -> None:
         num_hidden = 0
         num_visible = 0
         for w, i in widgets_and_items:

--- a/sub_view/mod_info_panel.py
+++ b/sub_view/mod_info_panel.py
@@ -93,18 +93,37 @@ class ModInfo:
         logger.info(f"Starting display mod info for info: {mod_info}")
         self.mod_info_name_value.setText(mod_info.get("name"))
         self.mod_info_package_id_value.setText(mod_info.get("packageId"))
-        if mod_info.get("authors"):
-            list_of_authors = mod_info.get("authors")["li"]
-            authors_text = ", ".join(list_of_authors)
-            self.mod_info_author_value.setText(authors_text)
+        if "authors" in mod_info:
+            if "li" in mod_info["authors"]:
+                list_of_authors = mod_info["authors"]["li"]
+                authors_text = ", ".join(list_of_authors)
+                self.mod_info_author_value.setText(authors_text)
+            else:
+                self.mod_info_author_value.setText("UNKNOWN")
+                logger.error(
+                    f"[authors] tag does not contain [li] tag: {mod_info['authors']}"
+                )
         else:
             self.mod_info_author_value.setText(mod_info.get("author"))
         self.mod_info_path_value.setText(mod_info.get("path"))
-        self.description.setText(mod_info.get("description"))
+
+        # Set the scrolling description for the Mod Info Panel
+        self.description.setText("")
+        if "description" in mod_info:
+            if mod_info["description"] is not None:
+                if isinstance(mod_info["description"], str):
+                    self.description.setText(mod_info["description"])
+                else:
+                    logger.error(
+                        f"[description] tag is not a string: {mod_info['description']}"
+                    )
+        # It is OK for the description value to be None (was not provided)
+        # It is OK for the description key to not be in mod_info
+
         # Get Preview.png
-        if mod_info.get("path"):
-            workshop_folder_path = mod_info.get("path")
-            logger.info(f"Mod path exists at: {workshop_folder_path}")
+        if mod_info.get("path") and isinstance(mod_info["path"], str):
+            workshop_folder_path = mod_info["path"]
+            logger.info(f"Got mod path for preview image: {workshop_folder_path}")
             # Look for a case-insensitive About folder
             invalid_folder_path_found = True
             about_folder_name = "About"
@@ -143,5 +162,8 @@ class ModInfo:
                     pixmap.scaled(self.preview_picture.size(), Qt.KeepAspectRatio)
                 )
         else:
+            logger.error(
+                f"[path] tag does not exist in mod_info, is empty, or is not string: {mod_info.get('path')}"
+            )
             self.preview_picture.setPixmap(None)
-        logger.info(f"Finished display mod info")
+        logger.info("Finished displaying mod info")

--- a/sub_view/mod_info_panel.py
+++ b/sub_view/mod_info_panel.py
@@ -2,9 +2,9 @@ import logging
 import os
 from typing import Any, Dict
 
-from PySide2.QtCore import *
-from PySide2.QtGui import *
-from PySide2.QtWidgets import *
+from PySide2.QtCore import Qt
+from PySide2.QtGui import QPixmap
+from PySide2.QtWidgets import QHBoxLayout, QLabel, QSizePolicy, QVBoxLayout
 
 from model.scroll_label import ScrollLabel
 

--- a/util/error.py
+++ b/util/error.py
@@ -1,4 +1,4 @@
-from PySide2.QtWidgets import *
+from PySide2.QtWidgets import QMessageBox
 from typing import Optional
 
 import logging

--- a/util/mods.py
+++ b/util/mods.py
@@ -5,8 +5,6 @@ import platform
 import traceback
 from typing import Any, Dict, List, Optional, Tuple
 
-from PySide2.QtWidgets import *
-
 from util.error import show_warning
 from util.schema import validate_mods_config_format
 from util.xml import non_utf8_xml_path_to_json, xml_path_to_json

--- a/util/mods.py
+++ b/util/mods.py
@@ -570,7 +570,7 @@ def get_dependencies_for_mods(
     # TODO: optimization: maybe everything could be based off publisher ID
     info_from_steam_package_id_to_name = {}
     if steam_db_rules:
-        tracking_dict = {}
+        tracking_dict: dict[str, set[str]] = {}
         steam_id_to_package_id = {}
 
         # Iterate through all workshop items in the Steam DB.
@@ -670,7 +670,7 @@ def get_dependencies_for_mods(
     return all_mods, info_from_steam_package_id_to_name
 
 
-def _get_num_dependencies(all_mods: Dict[str, Any], key_name: str) -> None:
+def _get_num_dependencies(all_mods: Dict[str, Any], key_name: str) -> int:
     """Debug func for getting total number of dependencies"""
     counter = 0
     for package_id, mod_data in all_mods.items():
@@ -958,7 +958,7 @@ def get_active_mods_from_config(config_path: str) -> Dict[str, Any]:
     logger.info(f"Getting active mods with Config Path: {config_path}")
     mod_data = xml_path_to_json(config_path)
     if validate_mods_config_format(mod_data):
-        empty_active_mods_dict = {}
+        empty_active_mods_dict: dict[str, Any] = {}
         for package_id in mod_data["ModsConfigData"]["activeMods"]["li"]:
             empty_active_mods_dict[package_id.lower()] = {}
         logger.info(
@@ -1003,7 +1003,7 @@ def populate_active_mods_workshop_data(
     return populated_mods, invalid_mods
 
 
-def merge_mod_data(*dict_args) -> Dict[str, Any]:
+def merge_mod_data(*dict_args: dict[str, Any]) -> Dict[str, Any]:
     """
     Given any number of dictionaries, shallow copy and merge into a new dict,
     precedence goes to key-value pairs in latter dictionaries.

--- a/util/proxy_style.py
+++ b/util/proxy_style.py
@@ -1,8 +1,8 @@
 from typing import Optional
 
-from PySide2.QtCore import *
-from PySide2.QtGui import *
-from PySide2.QtWidgets import *
+from PySide2.QtCore import Qt
+from PySide2.QtGui import QPainter, QPen
+from PySide2.QtWidgets import QProxyStyle, QStyle, QStyleOption, QWidget
 
 
 class ProxyStyle(QProxyStyle):

--- a/util/xml.py
+++ b/util/xml.py
@@ -16,7 +16,7 @@ def xml_path_to_json(path: str) -> Dict[str, Any]:
     :param path: path to the xml file
     :return: json dict of xml file contents
     """
-    data = {}
+    data: Dict[str, Any]= {}
     if os.path.exists(path):
         logger.info(f"Parsing XML file at: {path}")
         with open(path, encoding="utf-8") as f:
@@ -36,7 +36,7 @@ def non_utf8_xml_path_to_json(path: str) -> Dict[str, Any]:
     :param path: path to the xml file
     :return: json dict of xml file contents
     """
-    data = {}
+    data: Dict[str, Any] = {}
     if os.path.exists(path):
         logger.info(f"Parsing non UTF-8 XML file at: {path}")
         data = xmltodict.parse(fix_non_utf8_xml(path))
@@ -46,7 +46,7 @@ def non_utf8_xml_path_to_json(path: str) -> Dict[str, Any]:
     return data
 
 
-def fix_non_utf8_xml(path: str) -> str:
+def fix_non_utf8_xml(path: str) -> bytes:
     """
     Fixes files that are supposed to be UTF-8, but
     somehow are not. Iterates through every line and
@@ -58,7 +58,7 @@ def fix_non_utf8_xml(path: str) -> str:
     :return: the contents of the file
     """
     logger.info("Transforming non UTF-8 XML")
-    t = ""
+    t = b""
     with open(path, "rb") as problematic_file:
         t = problematic_file.read()
     r = t.decode("utf-8", "ignore").encode("utf-8")

--- a/view/game_configuration_panel.py
+++ b/view/game_configuration_panel.py
@@ -261,10 +261,10 @@ class GameConfiguration(QObject):
         logger.info("Finished GameConfiguration initialization")
 
     @property
-    def panel(self):
+    def panel(self) -> QVBoxLayout:
         return self._panel
 
-    def check_if_essential_paths_are_set(self) -> None:
+    def check_if_essential_paths_are_set(self) -> bool:
         """
         When the user starts the app for the first time, none
         of the paths will be set. We should check for this and
@@ -328,7 +328,7 @@ class GameConfiguration(QObject):
         if not os.path.exists(settings_path):
             logger.info(f"Settings file [{settings_path}] does not exist")
             # Create a new empty settings.json file
-            init_settings = {}
+            init_settings: dict[str, Any] = {}
             json_object = json.dumps(init_settings, indent=4)
             logger.info(f"Creating empty JSON to write: [{json_object}]")
             with open(settings_path, "w") as outfile:
@@ -445,7 +445,7 @@ class GameConfiguration(QObject):
             subprocess.Popen(["open", path])
         elif system_name == "Windows":
             logger.info(f"Opening {path} with startfile on Windows")
-            os.startfile(path)
+            os.startfile(path)  # type: ignore
         elif system_name == "Linux":
             logger.info(f"Opening {path} with xdg-open on Linux")
             subprocess.Popen(["xdg-open", path])
@@ -598,22 +598,22 @@ class GameConfiguration(QObject):
         self.local_folder_line.setText("")
         self.game_version_line.setText("")
 
-    def clear_game_folder_line(self):
+    def clear_game_folder_line(self) -> None:
         logger.info("USER ACTION: clear game folder line")
         self.update_persistent_storage("game_folder", "")
         self.game_folder_line.setText("")
 
-    def clear_config_folder_line(self):
+    def clear_config_folder_line(self) -> None:
         logger.info("USER ACTION: clear config folder line")
         self.update_persistent_storage("config_folder", "")
         self.config_folder_line.setText("")
 
-    def clear_workshop_folder_line(self):
+    def clear_workshop_folder_line(self) -> None:
         logger.info("USER ACTION: clear workshop folder line")
         self.update_persistent_storage("workshop_folder", "")
         self.workshop_folder_line.setText("")
 
-    def clear_local_folder_line(self):
+    def clear_local_folder_line(self) -> None:
         logger.info("USER ACTION: clear local folder line")
         self.update_persistent_storage("local_folder", "")
         self.local_folder_line.setText("")
@@ -749,19 +749,19 @@ class GameConfiguration(QObject):
                 f"Autodetected game folder path does not exist: {rimworld_mods_path}"
             )
 
-    def get_game_folder_path(self):
+    def get_game_folder_path(self) -> str:
         logger.info(
             f"Responding with requested Game Folder: {self.game_folder_line.text()}"
         )
         return self.game_folder_line.text()
 
-    def get_config_folder_path(self):
+    def get_config_folder_path(self) -> str:
         logger.info(
             f"Responding with requested Config Folder: {self.config_folder_line.text()}"
         )
         return self.config_folder_line.text()
 
-    def get_config_path(self):
+    def get_config_path(self) -> str:
         logger.info("Getting path to ModsConfig.xml")
         config_folder_path = self.get_config_folder_path()
         if config_folder_path:
@@ -771,19 +771,19 @@ class GameConfiguration(QObject):
         logger.info("ERROR: unable to get path to ModsConfig.xml")
         return ""
 
-    def get_workshop_folder_path(self):
+    def get_workshop_folder_path(self) -> str:
         logger.info(
             f"Responding with requested Workshop Folder: {self.workshop_folder_line.text()}"
         )
         return self.workshop_folder_line.text()
 
-    def get_local_folder_path(self):
+    def get_local_folder_path(self) -> str:
         logger.info(
             f"Responding with requested Local Folder: {self.local_folder_line.text()}"
         )
         return self.local_folder_line.text()
 
-    def open_settings_panel(self):
+    def open_settings_panel(self) -> None:
         """
         Opens the settings panel (as a modal window), blocking
         access to the rest of the application until it is closed.
@@ -794,13 +794,13 @@ class GameConfiguration(QObject):
         logger.info("USER ACTION: opening settings panel")
         self.settings_panel.show()
 
-    def do_autodetect(self):
+    def do_autodetect(self) -> None:
         self.autodetect_paths_by_platform()
 
-    def open_wiki_webbrowser(self):
+    def open_wiki_webbrowser(self) -> None:
         logger.info("USER ACTION: opening wiki")
         webbrowser.open("https://github.com/oceancabbage/RimSort/wiki")
 
-    def open_github_webbrowser(self):
+    def open_github_webbrowser(self) -> None:
         logger.info("USER ACTION: opening GitHub")
         webbrowser.open("https://github.com/oceancabbage/RimSort")

--- a/view/game_configuration_panel.py
+++ b/view/game_configuration_panel.py
@@ -9,9 +9,17 @@ from functools import partial
 from os.path import expanduser
 from typing import Any
 
-from PySide2.QtCore import *
-from PySide2.QtGui import *
-from PySide2.QtWidgets import *
+from PySide2.QtCore import QObject, QStandardPaths, Qt, Signal
+from PySide2.QtWidgets import (
+    QFileDialog,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QPushButton,
+    QToolButton,
+    QVBoxLayout,
+)
 
 from panel.settings_panel import SettingsPanel
 from util.error import *
@@ -189,9 +197,7 @@ class GameConfiguration(QObject):
         self.local_folder_select_button = QPushButton("...")
         self.local_folder_select_button.clicked.connect(self.set_local_folder)
         self.local_folder_select_button.setObjectName("RightButton")
-        self.local_folder_select_button.setToolTip(
-            "Set the Local Mods directory."
-        )
+        self.local_folder_select_button.setToolTip("Set the Local Mods directory.")
 
         # WIDGETS INTO CONTAINER LAYOUTS
         self.client_settings_row.addWidget(self.client_settings_button)
@@ -423,7 +429,7 @@ class GameConfiguration(QObject):
                     f"The path [{path}] you are trying to open does not exist. Has the "
                     "folder been deleted or moved? Try re-setting the path with the button "
                     "on the right or using the AutoDetect Paths functionality."
-                )
+                ),
             )
 
     def platform_specific_open(self, path: str) -> None:

--- a/view/main_content_panel.py
+++ b/view/main_content_panel.py
@@ -80,8 +80,8 @@ class MainContent:
         self.game_configuration = game_configuration
 
         # Restore cache initially set to empty
-        self.active_mods_data_restore_state = []
-        self.inactive_mods_data_restore_state = []
+        self.active_mods_data_restore_state: Dict[str, Any] = {}
+        self.inactive_mods_data_restore_state: Dict[str, Any] = {}
 
         self.game_version = ""
 
@@ -94,10 +94,6 @@ class MainContent:
             self.repopulate_lists(True)
 
         logger.info("Finished MainContent initialization")
-
-    @property
-    def panel(self):
-        return self._panel
 
     def mod_list_slot(self, package_id: str) -> None:
         """
@@ -256,7 +252,7 @@ class MainContent:
         if action == "edit_run_args":
             self._do_edit_run_args()
 
-    def _do_edit_run_args(self):
+    def _do_edit_run_args(self) -> None:
         """
         Opens a QDialogInput that allows the user to edit the run args
         that are configured to be passed to the Rimworld executable
@@ -276,7 +272,7 @@ class MainContent:
                 "runArgs", self.game_configuration.run_arguments
             )
 
-    def _do_platform_specific_game_launch(self, args) -> None:
+    def _do_platform_specific_game_launch(self, args: str) -> None:
         """
         This function starts the Rimworld game process in it's own subprocess,
         by launching the executable found in the configured game directory.

--- a/view/main_content_panel.py
+++ b/view/main_content_panel.py
@@ -4,9 +4,7 @@ import platform
 import subprocess
 from typing import Any, Dict
 
-from PySide2.QtCore import *
-from PySide2.QtGui import *
-from PySide2.QtWidgets import *
+from PySide2.QtWidgets import QFileDialog, QFrame, QHBoxLayout, QInputDialog, QLineEdit
 
 from sort.dependencies import *
 from sort.rimpy_sort import *

--- a/view/status_panel.py
+++ b/view/status_panel.py
@@ -40,7 +40,7 @@ class Status:
         logger.info("Finished Status initialization")
 
     @property
-    def panel(self):
+    def panel(self) -> QHBoxLayout:
         return self._panel
 
     def actions_slot(self, action: str) -> None:

--- a/view/status_panel.py
+++ b/view/status_panel.py
@@ -1,8 +1,6 @@
 import logging
 
-from PySide2.QtCore import *
-from PySide2.QtGui import *
-from PySide2.QtWidgets import *
+from PySide2.QtWidgets import QFrame, QHBoxLayout
 
 from model.animation_label import AnimationLabel
 


### PR DESCRIPTION
This PR does two main things:

* First, it gets rid of star imports, which is a bad practice
* Second, it adds type annotations where necessary, to be compliant with `mypy`. A new `setup.cfg` contains the `mypy` configuration.

This PR also moves the project up Python versions, to 3.9 or greater. This is because some typing annotations that were added here use the new subscript-able built-in types.

The goal here is to make the project cleaner and easier for new contributors to work with.