### PR TITLE
Fix .xml extension issues exporting, fix typo in import func, addt'l autodetect paths for Linux

### DIFF
--- a/view/game_configuration_panel.py
+++ b/view/game_configuration_panel.py
@@ -826,11 +826,18 @@ class GameConfiguration(QObject):
             f"/Users/{getpass.getuser()}/Library/Application Support/Rimworld/Config/",
             f"/Users/{getpass.getuser()}/Library/Application Support/Steam/steamapps/workshop/content/294100/",
         ]
-        linux_paths = [
-            f"{expanduser('~')}/.steam/debian-installation/steamapps/common/RimWorld",
-            f"{expanduser('~')}/.config/unity3d/Ludeon Studios/RimWorld by Ludeon Studios/Config",
-            f"{expanduser('~')}/.steam/debian-installation/steamapps/workshop/content/294100",
-        ]
+        if os.path.exists("{expanduser('~')}/.steam/debian-installation"):
+            linux_paths = [
+                f"{expanduser('~')}/.steam/debian-installation/steamapps/common/RimWorld",
+                f"{expanduser('~')}/.config/unity3d/Ludeon Studios/RimWorld by Ludeon Studios/Config",
+                f"{expanduser('~')}/.steam/debian-installation/steamapps/workshop/content/294100",
+            ]
+        else:
+            linux_paths = [ #TODO detect the path and not having hardcoded thing
+                f"{expanduser('~')}/.steam/steam/steamapps/common/RimWorld",
+                f"{expanduser('~')}/.config/unity3d/Ludeon Studios/RimWorld by Ludeon Studios/Config",
+                f"{expanduser('~')}/.steam/steam/steamapps/workshop/content/294100",
+            ]
         windows_paths = [
             os.path.join(
                 "C:" + os.sep,

--- a/view/main_content_panel.py
+++ b/view/main_content_panel.py
@@ -1401,7 +1401,10 @@ class MainContent:
                 logger.info(
                     f"Saving generated ModsConfig.xml to selected path: {file_path[0]}"
                 )
-                json_to_xml_write(mods_config_data, file_path[0] + ".xml")
+                if not file_path[0].endswith(".xml"):
+                    json_to_xml_write(mods_config_data, file_path[0]+".xml")
+                else:
+                    json_to_xml_write(mods_config_data, file_path[0])
             else:
                 logger.error("Could not export active mods")
         else:

--- a/view/main_content_panel.py
+++ b/view/main_content_panel.py
@@ -649,7 +649,7 @@ class MainContent:
         if action == "show_steamcmd_status":
             self._do_show_steamcmd_status()
         if action == "import_list_file_xml":
-            self._do_import_list_file_xml()()
+            self._do_import_list_file_xml()
         if action == "export_list_file_xml":
             self._do_export_list_file_xml()
         if action == "export_list_clipboard":


### PR DESCRIPTION
re fix #52 
the issue don't seem to appear on linux, its an issue with the windows file manager who add the .xml after selection the file i think